### PR TITLE
Remove debug println

### DIFF
--- a/cotton-ssdp/src/async_service.rs
+++ b/cotton-ssdp/src/async_service.rs
@@ -94,8 +94,6 @@ impl AsyncService {
 
         tokio::spawn(async move {
             loop {
-                println!("select");
-
                 tokio::select! {
                     _ = inner.multicast_socket.readable() => {
                         let mut buf = [0u8; 1500];


### PR DESCRIPTION
This removes what I assume to be a debug print statement which ends up filling stdout with "select". I've been using this library for a small project of mine and save for this small issue has been working great. :slightly_smiling_face: