### PR TITLE
Improve descriptor read/parsing in usb-host

### DIFF
--- a/cotton-usb-host/src/host/rp2040.rs
+++ b/cotton-usb-host/src/host/rp2040.rs
@@ -34,7 +34,7 @@ impl UsbShared {
             let bs = regs.buff_status().read().bits();
             for i in 0..15 {
                 if (bs & (3 << (i * 2))) != 0 {
-                    defmt::info!("IRQ wakes {}", i);
+                    defmt::trace!("IRQ wakes {}", i);
                     self.pipe_wakers[i].wake();
                 }
             }
@@ -141,7 +141,7 @@ impl Stream for Rp2040DeviceDetect {
         };
 
         if device_status != self.status {
-            defmt::println!(
+            defmt::trace!(
                 "DE ready {:x} {}->{}",
                 status.bits(),
                 self.status,
@@ -185,7 +185,7 @@ impl Future for Rp2040ControlEndpoint<'_> {
         let intr = regs.intr().read();
         let bcsh = regs.buff_cpu_should_handle().read();
         if (intr.bits() & 0x458) != 0 {
-            defmt::info!(
+            defmt::trace!(
                 "CE ready {:x} {:x} {:x}",
                 status.bits(),
                 intr.bits(),
@@ -338,7 +338,7 @@ impl Rp2040InterruptPipe {
             dpram
                 .ep_buffer_control((which * 2) as usize)
                 .modify(|_, w| w.available_0().set_bit());
-            defmt::println!(
+            defmt::trace!(
                 "IE ready inte {:x} iec {:x} ecr {:x} epbc {:x}",
                 regs.inte().read().bits(),
                 regs.int_ep_ctrl().read().bits(),
@@ -1113,30 +1113,30 @@ impl Rp2040HostController {
             );
             */
             if status.data_seq_error().bit() {
-                defmt::println!("DataSeqError");
+                defmt::trace!("DataSeqError");
                 return Err(UsbError::DataSeqError);
             }
             if status.stall_rec().bit() {
-                defmt::println!("Stall");
+                defmt::trace!("Stall");
                 return Err(UsbError::Stall);
             }
             // if status.nak_rec().bit() {
             //     return Err(UsbError::Nak);
             // }
             if status.rx_overflow().bit() {
-                defmt::println!("Overflow");
+                defmt::trace!("Overflow");
                 return Err(UsbError::Overflow);
             }
             if status.rx_timeout().bit() {
-                defmt::println!("Timeout");
+                defmt::trace!("Timeout");
                 return Err(UsbError::Timeout);
             }
             if status.bit_stuff_error().bit() {
-                defmt::println!("BitStuff");
+                defmt::trace!("BitStuff");
                 return Err(UsbError::BitStuffError);
             }
             if status.crc_error().bit() {
-                defmt::println!("CRCError");
+                defmt::trace!("CRCError");
                 return Err(UsbError::CrcError);
             }
 

--- a/cotton-usb-host/src/tests/wire.rs
+++ b/cotton-usb-host/src/tests/wire.rs
@@ -10,6 +10,7 @@ struct Interface {
 struct TestVisitor {
     configuration: Option<ConfigurationDescriptor>,
     interfaces: Vec<Interface>,
+    others: Vec<Vec<u8>>,
 }
 
 impl DescriptorVisitor for TestVisitor {
@@ -31,7 +32,10 @@ impl DescriptorVisitor for TestVisitor {
         self.interfaces.last_mut().unwrap().endpoints.push(*e);
     }
 
-    fn on_other(&mut self, _d: &[u8]) {}
+    fn on_other(&mut self, d: &[u8]) {
+        assert!(self.configuration.is_some());
+        self.others.push((*d).to_vec());
+    }
 }
 
 struct IgnoreVisitor;
@@ -62,6 +66,29 @@ const ELLA: &[u8] = &[
 
 const HUB: &[u8] = &[9, 41, 4, 0, 0, 50, 100, 0, 255];
 
+/*
+  Yamha DGX205 Midi Keyboard, CONFIG_DESCRIPTOR 101 bytes
+  Has 2 interfaces, one for the USB audio and one for the MIDI interface.
+  Includes Class-Specific descriptors (36) for midi.
+  ** Endpoints are oversized (9 bytes) **
+*/
+const YAMAHA: &[u8] = &[
+    9, 2, 101, 0, 2, 1, 0, 128, 50, 
+    9, 4, 0, 0, 0, 1, 1, 0, 0, 
+    9, 36, 1, 0, 1, 9, 0, 1, 1, 
+    9, 4, 1, 0, 2, 1, 3, 0, 0, 
+    7, 36, 1, 0, 1, 65, 0, 
+    6, 36, 2, 1, 1, 0, 
+    6, 36, 2, 2, 2, 0, 
+    9, 36, 3, 1, 3, 1, 2, 1, 0, 
+    9, 36, 3, 2, 4, 1, 1, 1, 0, 
+    9, 5, 2, 2, 32, 0, 0, 0, 0, 
+    5, 37, 1, 1, 1, 
+    9, 5, 129, 2, 32, 0, 0, 0, 0, 
+    5, 37, 1, 1, 3,
+];
+
+
 #[test]
 fn parse_ella() {
     parse_descriptors(ELLA, &mut ShowDescriptors);
@@ -74,6 +101,23 @@ fn parse_ella() {
     assert_eq!(v.interfaces[0].descriptor.bInterfaceClass, 255);
     assert_eq!(v.interfaces[0].endpoints.len(), 4);
     assert_eq!(v.interfaces[0].endpoints[3].bmAttributes, 3);
+}
+
+#[test]
+fn parse_yamaha() {
+    parse_descriptors(YAMAHA, &mut ShowDescriptors);
+    let mut v = TestVisitor::default();
+    parse_descriptors(YAMAHA, &mut v);
+    assert!(v.configuration.is_some());
+    let cfg = v.configuration.unwrap();
+    assert_eq!(cfg.bNumInterfaces, 2);
+    assert_eq!(v.interfaces.len(), 2);
+    assert_eq!(v.interfaces[0].descriptor.bInterfaceClass, 1);
+    assert_eq!(v.interfaces[0].endpoints.len(), 0);
+    assert_eq!(v.interfaces[1].endpoints.len(), 2);
+    assert_eq!(v.interfaces[1].endpoints[0].bmAttributes, 2);
+    assert_eq!(v.interfaces[1].endpoints[1].bEndpointAddress, 0x81);
+    assert_eq!(v.others.len(), 8);
 }
 
 #[test]

--- a/cotton-usb-host/src/usb_bus.rs
+++ b/cotton-usb-host/src/usb_bus.rs
@@ -937,6 +937,8 @@ impl<HC: HostController> UsbBus<HC> {
         visitor: &mut impl DescriptorVisitor,
     ) -> Result<(), UsbError> {
         // Handle descriptor suites > 64 byte
+        //   256 is arbitrary, but should be enough for most devices
+        //   TinyUSB uses 256 - https://github.com/hathach/tinyusb/blob/5572168994a29266df6cbf12b46919498d3ece66/examples/host/hid_controller/src/tusb_config.h#L103
         // 1. Read the first 9 bytes (configuration descriptor)
         // 2. If necessary, read the whole descriptor suite,
         //    using the length from the configuration descriptor

--- a/cotton-usb-host/src/wire.rs
+++ b/cotton-usb-host/src/wire.rs
@@ -346,8 +346,6 @@ pub fn parse_descriptors(buf: &[u8], v: &mut impl DescriptorVisitor) {
 
         match dtype {
             CONFIGURATION_DESCRIPTOR => {
-                dlen = Ord::min(dlen, size_of::<ConfigurationDescriptor>());
-
                 if let Ok(c) =
                     bytemuck::try_from_bytes(&buf[index..index + dlen])
                 {
@@ -355,8 +353,6 @@ pub fn parse_descriptors(buf: &[u8], v: &mut impl DescriptorVisitor) {
                 }
             }
             INTERFACE_DESCRIPTOR => {
-                dlen = Ord::min(dlen, size_of::<InterfaceDescriptor>());
-
                 if let Ok(i) =
                     bytemuck::try_from_bytes(&buf[index..index + dlen])
                 {
@@ -364,10 +360,10 @@ pub fn parse_descriptors(buf: &[u8], v: &mut impl DescriptorVisitor) {
                 }
             }
             ENDPOINT_DESCRIPTOR => {
-                dlen = Ord::min(dlen, size_of::<EndpointDescriptor>());
+                let dlen_min = Ord::min(dlen, size_of::<EndpointDescriptor>());
 
                 if let Ok(e) =
-                    bytemuck::try_from_bytes(&buf[index..index + dlen])
+                    bytemuck::try_from_bytes(&buf[index..index + dlen_min])
                 {
                     v.on_endpoint(e);
                 }


### PR DESCRIPTION
Now reads CONFIG_DESCRIPTOR first to extract the total length of the descriptor block, then re-reads the block with this length (max 256 due to no_alloc)

Adjusted descriptor parsing to ignore any extra bytes in outsize descriptors (i.e. `sizeof<InterfaceDescriptor>` > 9 ), instead of ignoring the descriptor. Undersize descriptors are still totally ignored.