### PR TITLE
Support USB HID

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "cotton-ssdp",
   "cotton-unique",
   "cotton-usb-host",
+  "cotton-usb-host-hid",
   "cotton-usb-host-msc",
   "cotton-w5500",
   "systemtests",

--- a/cotton-scsi/src/debug.rs
+++ b/cotton-scsi/src/debug.rs
@@ -9,7 +9,7 @@ extern crate std;
 pub use std::println;
 
 #[cfg(all(target_os = "none", feature = "defmt"))]
-pub use defmt::println;
+pub use defmt::debug as println;
 
 #[cfg(all(
     not(feature = "std"),

--- a/cotton-usb-host-hid/Cargo.toml
+++ b/cotton-usb-host-hid/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "cotton-usb-host-hid"
+version = "0.1.0"
+description = "USB HID host for embedded devices"
+homepage = "https://github.com/pdh11/cotton"
+repository = "https://github.com/pdh11/cotton"
+categories = []
+edition = "2021"
+authors = ["Jonathan Pallant <github@thejpster.org.uk>"]
+license = "CC0-1.0"
+rust-version = "1.80"
+
+[dependencies]
+cotton-usb-host = { version = "0.1", path = "../cotton-usb-host", default-features = false }
+futures = { version = "0.3", default-features = false }
+defmt = { version = "0.3.10", optional = true }
+
+[features]
+default = ["std"]
+std = ["cotton-usb-host/std"]
+defmt = ["dep:defmt", "cotton-usb-host/defmt"]

--- a/cotton-usb-host-hid/Cargo.toml
+++ b/cotton-usb-host-hid/Cargo.toml
@@ -11,7 +11,7 @@ license = "CC0-1.0"
 rust-version = "1.80"
 
 [dependencies]
-cotton-usb-host = { version = "0.1", path = "../cotton-usb-host", default-features = false }
+cotton-usb-host = { version = "0.2", path = "../cotton-usb-host", default-features = false }
 futures = { version = "0.3", default-features = false }
 defmt = { version = "0.3.10", optional = true }
 

--- a/cotton-usb-host-hid/LICENSE
+++ b/cotton-usb-host-hid/LICENSE
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/cotton-usb-host-hid/README.md
+++ b/cotton-usb-host-hid/README.md
@@ -1,0 +1,23 @@
+[![CI status](https://github.com/pdh11/cotton/actions/workflows/ci.yml/badge.svg)](https://github.com/pdh11/cotton/actions)
+[![codecov](https://codecov.io/gh/pdh11/cotton/branch/main/graph/badge.svg?token=SMSZEPGRHA)](https://codecov.io/gh/pdh11/cotton)
+[![dependency status](https://deps.rs/repo/github/pdh11/cotton/status.svg)](https://deps.rs/repo/github/pdh11/cotton)
+[![Crates.io](https://img.shields.io/crates/v/cotton-usb-host-msc)](https://crates.io/crates/cotton-usb-host-msc)
+[![Crates.io](https://img.shields.io/crates/d/cotton-usb-host-msc)](https://crates.io/crates/cotton-usb-host-msc)
+[![docs.rs](https://img.shields.io/docsrs/cotton-usb-host-msc)](https://docs.rs/cotton-usb-host-msc/latest/cotton_usb-host-msc/)
+[![License: CC0-1.0](https://img.shields.io/badge/License-CC0_1.0-lightgrey.svg)](http://creativecommons.org/publicdomain/zero/1.0/)
+
+# cotton-usb-host-hid
+
+Part of the [Cotton](https://github.com/pdh11/cotton) project.
+
+## A no-std, no-alloc USB HID _host_ driver for embedded devices
+
+This crate lets you use HID Devices from a microcontroller such as a
+Raspberry&nbsp;Pi Pico.
+
+The microcontroller here acts as the USB _host_. This crate does not
+help you if you want your microcontroller to _appear_ as a HID
+device when plugged into a USB host such a laptop -- that's the other
+way around!
+
+Currently only HID Keyboards in 'BIOS' mode are supported.

--- a/cotton-usb-host-hid/src/debug.rs
+++ b/cotton-usb-host-hid/src/debug.rs
@@ -1,0 +1,28 @@
+// feature=defmt and os=none? use defmt
+//   feature=std? use std
+//     neither? use nothing
+
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "std")]
+pub use std::println;
+
+#[cfg(all(target_os = "none", feature = "defmt"))]
+pub use defmt::println;
+
+#[cfg(all(
+    not(feature = "std"),
+    not(all(target_os = "none", feature = "defmt"))
+))]
+#[macro_export]
+macro_rules! println {
+    ($fmt:expr) => {};
+    ($fmt:expr, $($arg:tt)*) => {};
+}
+
+#[cfg(all(
+    not(feature = "std"),
+    not(all(target_os = "none", feature = "defmt"))
+))]
+pub use println;

--- a/cotton-usb-host-hid/src/debug.rs
+++ b/cotton-usb-host-hid/src/debug.rs
@@ -9,7 +9,7 @@ extern crate std;
 pub use std::println;
 
 #[cfg(all(target_os = "none", feature = "defmt"))]
-pub use defmt::println;
+pub use defmt::debug as println;
 
 #[cfg(all(
     not(feature = "std"),

--- a/cotton-usb-host-hid/src/hid.rs
+++ b/cotton-usb-host-hid/src/hid.rs
@@ -45,7 +45,7 @@ impl<'a, HC: HostController> Hid<'a, HC> {
     pub fn handle(&mut self) -> impl Stream<Item = HidReport> + '_ {
         self.bus
             .interrupt_endpoint_in(
-                self.device.address(),
+                &self.device,
                 self.in_ep,
                 Self::PKT_LEN,
                 Self::INTERVAL_MS,

--- a/cotton-usb-host-hid/src/hid.rs
+++ b/cotton-usb-host-hid/src/hid.rs
@@ -16,6 +16,8 @@ pub struct Hid<'a, HC: HostController> {
 /// A report from our HID device
 ///
 /// NB: Only supports 8-byte reports from a Boot mode keyboard.
+#[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct HidReport {
     pub bytes: [u8; 8],
 }

--- a/cotton-usb-host-hid/src/hid.rs
+++ b/cotton-usb-host-hid/src/hid.rs
@@ -1,0 +1,112 @@
+use cotton_usb_host::{
+    device::identify::IdentifyFromDescriptors,
+    usb_bus::{HostController, UsbBus, UsbDevice, UsbError},
+    wire::{ConfigurationDescriptor, DescriptorVisitor, InterfaceDescriptor},
+};
+use futures::{Stream, StreamExt};
+
+use crate::debug;
+
+pub struct Hid<'a, HC: HostController> {
+    bus: &'a UsbBus<HC>,
+    device: UsbDevice,
+    in_ep: u8,
+}
+
+/// A report from our HID device
+///
+/// NB: Only supports 8-byte reports from a Boot mode keyboard.
+pub struct HidReport {
+    pub bytes: [u8; 8],
+}
+
+impl<'a, HC: HostController> Hid<'a, HC> {
+    const PKT_LEN: u16 = 8;
+    const INTERVAL_MS: u8 = 10;
+
+    pub fn new(
+        bus: &'a UsbBus<HC>,
+        device: UsbDevice,
+    ) -> Result<Self, UsbError> {
+        let in_ep = device.in_endpoints().iter().next().unwrap_or_default();
+        Ok(Self { bus, device, in_ep })
+    }
+
+    /// Produce a stream of HID reports from a Boot-mode keyboard
+    pub fn handle(&mut self) -> impl Stream<Item = HidReport> + '_ {
+        self.bus
+            .interrupt_endpoint_in(
+                self.device.address(),
+                self.in_ep,
+                Self::PKT_LEN,
+                Self::INTERVAL_MS,
+            )
+            .map(|pkt| HidReport {
+                bytes: [
+                    pkt.data[0],
+                    pkt.data[1],
+                    pkt.data[2],
+                    pkt.data[3],
+                    pkt.data[4],
+                    pkt.data[5],
+                    pkt.data[6],
+                    pkt.data[7],
+                ],
+            })
+    }
+}
+
+#[derive(Default)]
+pub struct IdentifyHid {
+    current_configuration: Option<u8>,
+    hid_configuration: Option<u8>,
+}
+
+impl IdentifyHid {
+    /// This is the bInterfaceClass for HID devices
+    pub const INTERFACE_CLASS: u8 = 3;
+    /// This is the bInterfaceProtocol for Keyboards
+    pub const INTERFACE_PROTOCOL_KEYBOARD: u8 = 1;
+    /// This subclass means the keyboard support 'Boot' mode, which is a simple
+    /// mode designed for use with a PC BIOS (doing PS/2 emulation). This is
+    /// the mode we want, because it means we can assume what the descriptor
+    /// looks like without having to parse it.
+    ///
+    /// See https://www.usb.org/sites/default/files/hid1_11.pdf Appendix B.
+    pub const INTERFACE_SUBCLASS_BOOT: u8 = 1;
+}
+
+impl DescriptorVisitor for IdentifyHid {
+    fn on_configuration(&mut self, c: &ConfigurationDescriptor) {
+        self.current_configuration = Some(c.bConfigurationValue);
+    }
+    fn on_interface(&mut self, i: &InterfaceDescriptor) {
+        match (
+            i.bInterfaceClass,
+            i.bInterfaceSubClass,
+            i.bInterfaceProtocol,
+        ) {
+            (
+                Self::INTERFACE_CLASS,
+                Self::INTERFACE_SUBCLASS_BOOT,
+                Self::INTERFACE_PROTOCOL_KEYBOARD,
+            ) => {
+                self.hid_configuration = self.current_configuration;
+            }
+            _ => {
+                debug::println!(
+                    "class {} subclass {} protocol {}",
+                    i.bInterfaceClass,
+                    i.bInterfaceSubClass,
+                    i.bInterfaceProtocol
+                );
+            }
+        }
+    }
+}
+
+impl IdentifyFromDescriptors for IdentifyHid {
+    fn identify(&self) -> Option<u8> {
+        self.hid_configuration
+    }
+}

--- a/cotton-usb-host-hid/src/hid.rs
+++ b/cotton-usb-host-hid/src/hid.rs
@@ -13,6 +13,13 @@ pub struct Hid<'a, HC: HostController> {
     in_ep: u8,
 }
 
+#[cfg(feature = "defmt")]
+impl<HC> defmt::Format for Hid<'_, HC> where HC: HostController {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "Hid(dev={}, ep={=u8})", self.device, self.in_ep);
+    }
+}
+
 /// A report from our HID device
 ///
 /// NB: Only supports 8-byte reports from a Boot mode keyboard.

--- a/cotton-usb-host-hid/src/lib.rs
+++ b/cotton-usb-host-hid/src/lib.rs
@@ -1,0 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+mod debug;
+pub mod hid;
+pub use hid::{Hid, IdentifyHid};

--- a/cotton-usb-host-msc/src/debug.rs
+++ b/cotton-usb-host-msc/src/debug.rs
@@ -9,7 +9,7 @@ extern crate std;
 pub use std::println;
 
 #[cfg(all(target_os = "none", feature = "defmt"))]
-pub use defmt::println;
+pub use defmt::debug as println;
 
 #[cfg(all(
     not(feature = "std"),

--- a/cotton-usb-host/src/debug.rs
+++ b/cotton-usb-host/src/debug.rs
@@ -9,7 +9,7 @@ extern crate std;
 pub use std::println;
 
 #[cfg(all(target_os = "none", feature = "defmt"))]
-pub use defmt::println;
+pub use defmt::debug as println;
 
 #[cfg(all(
     not(feature = "std"),

--- a/cross/rp2040-w5500-rtic2/Cargo.toml
+++ b/cross/rp2040-w5500-rtic2/Cargo.toml
@@ -32,7 +32,7 @@ codegen-units = 1
 opt-level = "s"
 lto = true
 codegen-units = 1
-strip = "symbols"
+debug = 2
 
 [dependencies]
 cotton-usb-host = { path = "../../cotton-usb-host", default-features = false, features = [

--- a/cross/rp2040-w5500-rtic2/Cargo.toml
+++ b/cross/rp2040-w5500-rtic2/Cargo.toml
@@ -38,6 +38,9 @@ strip = "symbols"
 cotton-usb-host = { path = "../../cotton-usb-host", default-features = false, features = [
   "rp2040",
 ] }
+cotton-usb-host-hid = { path = "../../cotton-usb-host-hid", default-features = false, features = [
+  "defmt",
+] }
 cotton-usb-host-msc = { path = "../../cotton-usb-host-msc", default-features = false, features = [
   "defmt",
 ] }
@@ -55,6 +58,7 @@ cortex-m = "0.7.7"
 cortex-m-rt = "0.7"
 defmt = "1"
 defmt-rtt = "1"
+futures = { version = "0.3", default-features = false }
 panic-probe = { version = "1", features = ["print-defmt"] }
 rp-pico = "0.9"
 rp2040-flash = "0.5"

--- a/cross/rp2040-w5500-rtic2/Cargo.toml
+++ b/cross/rp2040-w5500-rtic2/Cargo.toml
@@ -24,8 +24,7 @@ doctest = false
 harness = false
 
 [profile.dev]
-opt-level = "s"
-lto = true
+opt-level = 1
 codegen-units = 1
 
 [profile.release]

--- a/cross/rp2040-w5500-rtic2/Cargo.toml
+++ b/cross/rp2040-w5500-rtic2/Cargo.toml
@@ -88,3 +88,4 @@ rtic-common = "1"
 futures-util = { version = "0.3", default-features = false }
 static_cell = "2"
 portable-atomic = { version = "1", features = ["critical-section"] }
+pc-keyboard = { git = "https://github.com/rust-embedded-community/pc-keyboard.git", rev="6d03cf7" }

--- a/cross/rp2040-w5500-rtic2/src/bin/rp2040-usb-hid-boot-keyboard.rs
+++ b/cross/rp2040-w5500-rtic2/src/bin/rp2040-usb-hid-boot-keyboard.rs
@@ -1,0 +1,206 @@
+#![no_std]
+#![no_main]
+
+use defmt_rtt as _; // global logger
+use panic_probe as _;
+use rp_pico as _; // includes boot2
+
+#[rtic::app(device = rp_pico::hal::pac, dispatchers = [ADC_IRQ_FIFO])]
+mod app {
+    use core::future::Future;
+    use core::pin::pin;
+    use cotton_usb_host::device::identify::IdentifyFromDescriptors;
+    use cotton_usb_host::host::rp2040::{UsbShared, UsbStatics};
+    use cotton_usb_host::usb_bus::{DeviceEvent, HubState, UsbBus};
+    use cotton_usb_host_hid::{hid, Hid, IdentifyHid};
+    use futures_util::StreamExt;
+    use rp_pico::pac;
+    use rtic_monotonics::rp2040::prelude::*;
+    use static_cell::ConstStaticCell;
+    use cotton_usb_host::wire::ShowDescriptors;
+
+    #[inline(never)]
+    unsafe fn unique_flash_id() -> cotton_unique::UniqueId {
+        let mut unique_bytes = [0u8; 16];
+        cortex_m::interrupt::free(|_| {
+            rp2040_flash::flash::flash_unique_id(&mut unique_bytes, true);
+        });
+        cotton_unique::UniqueId::new(&unique_bytes)
+    }
+
+    #[shared]
+    struct Shared {
+        shared: &'static UsbShared,
+    }
+
+    #[local]
+    struct Local {
+        resets: pac::RESETS,
+        regs: Option<pac::USBCTRL_REGS>,
+        dpram: Option<pac::USBCTRL_DPRAM>,
+    }
+
+    rp2040_timer_monotonic!(Mono); // 1MHz!
+
+    #[init()]
+    fn init(c: init::Context) -> (Shared, Local) {
+        defmt::println!(
+            "{} from {} {}-g{}",
+            env!("CARGO_BIN_NAME"),
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+            git_version::git_version!()
+        );
+
+        let _unique_id = unsafe { unique_flash_id() };
+
+        let device = c.device;
+        let mut resets = device.RESETS;
+        let mut watchdog =
+            rp2040_hal::watchdog::Watchdog::new(device.WATCHDOG);
+
+        let _clocks = rp2040_hal::clocks::init_clocks_and_plls(
+            rp_pico::XOSC_CRYSTAL_FREQ,
+            device.XOSC,
+            device.CLOCKS,
+            device.PLL_SYS,
+            device.PLL_USB,
+            &mut resets,
+            &mut watchdog,
+        )
+        .ok()
+        .unwrap();
+
+        Mono::start(device.TIMER, &resets);
+
+        // The timer doesn't increment if either RP2040 core is under
+        // debug, unless the DBGPAUSE bits are cleared, which they
+        // aren't by default.
+        //
+        // There is no neat and tidy method on hal::Timer to clear
+        // these bits, and they can't be cleared before
+        // hal::Timer::new because it resets the peripheral. So we
+        // have to steal the peripheral, but that's OK because we only
+        // access the DBGPAUSE register, which nobody else is
+        // accessing.
+        unsafe {
+            rp2040_hal::pac::TIMER::steal()
+                .dbgpause()
+                .write(|w| w.bits(0));
+        }
+
+        usb_task::spawn().unwrap();
+
+        static USB_SHARED: UsbShared = UsbShared::new();
+
+        (
+            Shared {
+                shared: &USB_SHARED,
+            },
+            Local {
+                regs: Some(device.USBCTRL_REGS),
+                dpram: Some(device.USBCTRL_DPRAM),
+                resets,
+            },
+        )
+    }
+
+    fn rtic_delay(ms: usize) -> impl Future<Output = ()> {
+        Mono::delay(<Mono as rtic_monotonics::Monotonic>::Duration::millis(
+            ms as u64,
+        ))
+    }
+
+    #[task(local = [regs, dpram, resets], shared = [&shared], priority = 2)]
+    async fn usb_task(cx: usb_task::Context) {
+        static USB_STATICS: ConstStaticCell<UsbStatics> =
+            ConstStaticCell::new(UsbStatics::new());
+        let statics = USB_STATICS.take();
+
+        let driver = cotton_usb_host::host::rp2040::Rp2040HostController::new(
+            cx.local.resets,
+            cx.local.regs.take().unwrap(),
+            cx.local.dpram.take().unwrap(),
+            cx.shared.shared,
+            statics,
+        );
+        let hub_state = HubState::default();
+        let stack = UsbBus::new(driver);
+
+        let mut p = pin!(stack.device_events(&hub_state, rtic_delay));
+
+        loop {
+            defmt::println!("loop");
+            let device = p.next().await;
+
+            if let Some(DeviceEvent::EnumerationError(h, p, e)) = device {
+                defmt::println!(
+                    "Enumeration error {} on hub {} port {}",
+                    e,
+                    h,
+                    p
+                );
+            }
+
+            defmt::println!("{:?}", hub_state.topology());
+
+            if let Some(DeviceEvent::Connect(device, info)) = device {
+                defmt::println!("Got device {:x} {:x}", device, info);
+
+                let _ = stack.get_configuration(&device, &mut ShowDescriptors).await;
+
+                let mut hid = IdentifyHid::default();
+                let Ok(()) = stack.get_configuration(&device, &mut hid).await
+                else {
+                    continue;
+                };
+                if let Some(cfg) = hid.identify() {
+                    defmt::println!("Could be HID");
+                    let Ok(device) = stack.configure(device, cfg).await else {
+                        continue;
+                    };
+                    let address = device.address();
+                    let Ok(mut ms) = Hid::new(&stack, device) else {
+                        continue;
+                    };
+                    defmt::println!("Is HID!");
+
+                    let hid_stream = pin!(ms.handle());
+
+                    enum Event {
+                        Report(hid::HidReport),
+                        Device(DeviceEvent),
+                    }
+
+                    let mut stream = futures::stream::select(
+                        hid_stream.map(Event::Report),
+                        p.as_mut().map(Event::Device),
+                    );
+
+                    loop {
+                        if let Some(ev) = stream.next().await {
+                            match ev {
+                                Event::Device(ev) => {
+                                    if let DeviceEvent::Disconnect(bs) = ev {
+                                        if bs.contains(address) {
+                                            defmt::println!("HID disconnect");
+                                            break;
+                                        }
+                                    }
+                                }
+                                Event::Report(hr) => {
+                                    defmt::println!("HID report {:?}", hr);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[task(binds = USBCTRL_IRQ, shared = [&shared], priority = 2)]
+    fn usb_interrupt(cx: usb_interrupt::Context) {
+        cx.shared.shared.on_irq();
+    }
+}

--- a/cross/rp2040-w5500-rtic2/src/bin/rp2040-usb-hid-boot-keyboard.rs
+++ b/cross/rp2040-w5500-rtic2/src/bin/rp2040-usb-hid-boot-keyboard.rs
@@ -44,7 +44,7 @@ mod app {
 
     #[init()]
     fn init(c: init::Context) -> (Shared, Local) {
-        defmt::println!(
+        defmt::info!(
             "{} from {} {}-g{}",
             env!("CARGO_BIN_NAME"),
             env!("CARGO_PKG_NAME"),
@@ -130,11 +130,11 @@ mod app {
         let mut p = pin!(stack.device_events(&hub_state, rtic_delay));
 
         loop {
-            defmt::println!("loop");
+            defmt::info!("loop");
             let device = p.next().await;
 
             if let Some(DeviceEvent::EnumerationError(h, p, e)) = device {
-                defmt::println!(
+                defmt::info!(
                     "Enumeration error {} on hub {} port {}",
                     e,
                     h,
@@ -142,10 +142,10 @@ mod app {
                 );
             }
 
-            defmt::println!("{:?}", hub_state.topology());
+            defmt::info!("{:?}", hub_state.topology());
 
             if let Some(DeviceEvent::Connect(device, info)) = device {
-                defmt::println!("Got device {:x} {:x}", device, info);
+                defmt::info!("Got device {:x} {:x}", device, info);
 
                 let _ = stack.get_configuration(&device, &mut ShowDescriptors).await;
 
@@ -155,7 +155,7 @@ mod app {
                     continue;
                 };
                 if let Some(cfg) = hid.identify() {
-                    defmt::println!("Could be HID");
+                    defmt::info!("Could be HID");
                     let Ok(device) = stack.configure(device, cfg).await else {
                         continue;
                     };
@@ -163,7 +163,7 @@ mod app {
                     let Ok(mut ms) = Hid::new(&stack, device) else {
                         continue;
                     };
-                    defmt::println!("Is HID!");
+                    defmt::info!("Is HID!");
 
                     let hid_stream = pin!(ms.handle());
 
@@ -183,13 +183,13 @@ mod app {
                                 Event::Device(ev) => {
                                     if let DeviceEvent::Disconnect(bs) = ev {
                                         if bs.contains(address) {
-                                            defmt::println!("HID disconnect");
+                                            defmt::info!("HID disconnect");
                                             break;
                                         }
                                     }
                                 }
                                 Event::Report(hr) => {
-                                    defmt::println!("HID report {:?}", hr);
+                                    defmt::info!("HID report {:?}", hr);
                                 }
                             }
                         }
@@ -203,4 +203,7 @@ mod app {
     fn usb_interrupt(cx: usb_interrupt::Context) {
         cx.shared.shared.on_irq();
     }
+
+    defmt::timestamp!("{=u64:tus}", Mono::now().ticks());
 }
+

--- a/cross/rp2040-w5500-rtic2/src/bin/rp2040-usb-hid-boot-keyboard.rs
+++ b/cross/rp2040-w5500-rtic2/src/bin/rp2040-usb-hid-boot-keyboard.rs
@@ -12,12 +12,12 @@ mod app {
     use cotton_usb_host::device::identify::IdentifyFromDescriptors;
     use cotton_usb_host::host::rp2040::{UsbShared, UsbStatics};
     use cotton_usb_host::usb_bus::{DeviceEvent, HubState, UsbBus};
+    use cotton_usb_host::wire::ShowDescriptors;
     use cotton_usb_host_hid::{hid, Hid, IdentifyHid};
     use futures_util::StreamExt;
     use rp_pico::pac;
     use rtic_monotonics::rp2040::prelude::*;
     use static_cell::ConstStaticCell;
-    use cotton_usb_host::wire::ShowDescriptors;
 
     #[inline(never)]
     unsafe fn unique_flash_id() -> cotton_unique::UniqueId {
@@ -126,48 +126,66 @@ mod app {
         );
         let hub_state = HubState::default();
         let stack = UsbBus::new(driver);
-        let mut kb = pc_keyboard::UsbKeyboard::new(pc_keyboard::layouts::Uk105Key, pc_keyboard::HandleControl::MapLettersToUnicode);
+        let mut kb = pc_keyboard::UsbKeyboard::new(
+            pc_keyboard::layouts::Uk105Key,
+            pc_keyboard::HandleControl::MapLettersToUnicode,
+        );
 
         let mut p = pin!(stack.device_events(&hub_state, rtic_delay));
 
         loop {
-            defmt::info!("loop");
+            defmt::debug!("> Sleeping on event...");
             let device = p.next().await;
 
             if let Some(DeviceEvent::EnumerationError(h, p, e)) = device {
-                defmt::info!(
-                    "Enumeration error {} on hub {} port {}",
+                defmt::error!(
+                    "< Enumeration error {} on hub {} port {}",
                     e,
                     h,
                     p
                 );
             }
 
-            defmt::info!("{:?}", hub_state.topology());
+            defmt::info!("Hub Topology: {:?}", hub_state.topology());
 
             if let Some(DeviceEvent::Connect(device, info)) = device {
-                defmt::info!("Got device {:x} {:x}", device, info);
+                defmt::info!(
+                    "< DeviceEvent::Connect({:x}, {:x})",
+                    device,
+                    info
+                );
 
-                let _ = stack.get_configuration(&device, &mut ShowDescriptors).await;
+                let _ = stack
+                    .get_configuration(&device, &mut ShowDescriptors)
+                    .await;
 
                 let mut hid = IdentifyHid::default();
-                let Ok(()) = stack.get_configuration(&device, &mut hid).await
-                else {
+                if let Err(e) = stack.get_configuration(&device, &mut hid).await {
+                    defmt::error!("Failed to get device config: {:?}", e);
                     continue;
                 };
                 if let Some(cfg) = hid.identify() {
-                    defmt::info!("Could be HID");
-                    let Ok(device) = stack.configure(device, cfg).await else {
-                        continue;
+                    defmt::info!("- Could be HID...");
+                    let device = match stack.configure(device, cfg).await {
+                        Ok(device) => device,
+                        Err(e) => {
+                            defmt::warn!("- Was not HID, got error: {:?}", e);
+                            continue;
+                        }
                     };
                     let address = device.address();
-                    let Ok(mut ms) = Hid::new(&stack, device) else {
-                        continue;
+                    let mut ms = match Hid::new(&stack, device) {
+                        Ok(ms) => ms,
+                        Err(e) => {
+                            defmt::warn!("- Hid::new() returned {:?}", e);
+                            continue;
+                        }
                     };
-                    defmt::info!("Is HID!");
+                    defmt::info!("< Got HID device {:?}", ms);
 
                     let hid_stream = pin!(ms.handle());
 
+                    #[derive(defmt::Format)]
                     enum Event {
                         Report(hid::HidReport),
                         Device(DeviceEvent),
@@ -179,32 +197,42 @@ mod app {
                     );
 
                     loop {
+                        defmt::debug!("> Sleeping on select...");
                         if let Some(ev) = stream.next().await {
+                            defmt::debug!("< Got {}", ev);
                             match ev {
                                 Event::Device(ev) => {
                                     if let DeviceEvent::Disconnect(bs) = ev {
                                         if bs.contains(address) {
-                                            defmt::info!("HID disconnect");
+                                            defmt::info!("< HID disconnect");
                                             break;
                                         }
                                     }
                                 }
                                 Event::Report(hr) => {
-                                    defmt::info!("HID report {:?}", hr);
-                                    let report = pc_keyboard::UsbBootKeyboardReport {
-                                        modifiers: hr.bytes[0],
-                                        keys: [hr.bytes[2], hr.bytes[3], hr.bytes[4], hr.bytes[5], hr.bytes[6], hr.bytes[7]],
-                                    };
-                                    for key_event in kb.handle_report(&report) {
+                                    let report =
+                                        pc_keyboard::UsbBootKeyboardReport {
+                                            modifiers: hr.bytes[0],
+                                            keys: [
+                                                hr.bytes[2],
+                                                hr.bytes[3],
+                                                hr.bytes[4],
+                                                hr.bytes[5],
+                                                hr.bytes[6],
+                                                hr.bytes[7],
+                                            ],
+                                        };
+                                    for key_event in kb.handle_report(&report)
+                                    {
                                         match key_event {
                                             pc_keyboard::DecodedKey::RawKey(key_code) => {
-                                                defmt::info!("Raw Key: {:?}", key_code as u8);
+                                                defmt::info!("< Raw Key: {:?}", key_code as u8);
                                             },
                                             pc_keyboard::DecodedKey::Unicode(c) if c.is_alphanumeric() => {
-                                                defmt::info!("Unicode: '{=char}'", c);
+                                                defmt::info!("< Unicode: '{=char}'", c);
                                             },
                                             pc_keyboard::DecodedKey::Unicode(c) => {
-                                                defmt::info!("Unicode: \\U+{=u32:04X}", c as u32);
+                                                defmt::info!("< Unicode: \\U+{=u32:04X}", c as u32);
                                             },
                                         }
                                     }
@@ -224,4 +252,3 @@ mod app {
 
     defmt::timestamp!("{=u64:tus}", Mono::now().ticks());
 }
-


### PR DESCRIPTION
Adds support for USB HID.

Tested with a keyboard, and a keyboard plugged into a hub.

```console
$ DEFMT_LOG=debug cargo run --release --bin rp2040-usb-hid-boot-keyboard
   Compiling cross-rp2040-w5500 v0.0.1 (/home/jonathan/Documents/github/thejpster/cotton/cross/rp2040-w5500-rtic2)
    Finished `release` profile [optimized + debuginfo] target(s) in 1.12s
     Running `probe-rs run --chip RP2040 target/thumbv6m-none-eabi/release/rp2040-usb-hid-boot-keyboard`
      Erasing ✔ 100% [####################]  36.00 KiB @  65.12 KiB/s (took 1s)
  Programming ✔ 100% [####################]  36.00 KiB @  30.23 KiB/s (took 1s)                                                                                    Finished in 1.75s
00:00:00.000464 [INFO ] rp2040-usb-hid-boot-keyboard from cross-rp2040-w5500 0.0.1-gdfa2567-modified (rp2040_usb_hid_boot_keyboard src/bin/rp2040-usb-hid-boot-keyboard.rs:52)
00:00:00.001407 [DEBUG] > Sleeping on event... (rp2040_usb_hid_boot_keyboard src/bin/rp2040-usb-hid-boot-keyboard.rs:153)
00:00:00.213168 [INFO ] Hub Topology: 0:(31) (rp2040_usb_hid_boot_keyboard src/bin/rp2040-usb-hid-boot-keyboard.rs:167)
00:00:00.213248 [INFO ] < DeviceEvent::Connect(UnconfiguredDevice { usb_address: 1f, usb_speed: Full12, packet_size_ep0: 8 }, DeviceInfo { vid: 24ae, pid: 4005, class: 0, subclass: 0 }) (rp2040_usb_hid_boot_keyboard src/bin/rp2040-usb-hid-boot-keyboard.rs:170)
00:00:00.216541 [DEBUG] ConfigurationDescriptor { bLength: 9, bDescriptorType: 2, wTotalLength: [91, 0], bNumInterfaces: 3, bConfigurationValue: 1, iConfiguration: 0, bmAttributes: 160, bMaxPower: 175 } (cotton_usb_host cotton-usb-host/src/wire.rs:311)
00:00:00.216602 [DEBUG]   InterfaceDescriptor { bLength: 9, bDescriptorType: 4, bInterfaceNumber: 0, bAlternateSetting: 0, bNumEndpoints: 1, bInterfaceClass: 3, bInterfaceSubClass: 1, bInterfaceProtocol: 1, iInterface: 0 } (cotton_usb_host cotton-usb-host/src/wire.rs:314)
00:00:00.216646 [DEBUG]   class type 33 len 9 skipped (cotton_usb_host cotton-usb-host/src/wire.rs:328)
00:00:00.216697 [DEBUG]     EndpointDescriptor { bLength: 7, bDescriptorType: 5, bEndpointAddress: 129, bmAttributes: 3, wMaxPacketSize: [8, 0], bInterval: 1 } (cotton_usb_host cotton-usb-host/src/wire.rs:317)
00:00:00.216742 [DEBUG]   InterfaceDescriptor { bLength: 9, bDescriptorType: 4, bInterfaceNumber: 1, bAlternateSetting: 0, bNumEndpoints: 1, bInterfaceClass: 3, bInterfaceSubClass: 0, bInterfaceProtocol: 0, iInterface: 0 } (cotton_usb_host cotton-usb-host/src/wire.rs:314)
00:00:00.216771 [DEBUG]   class type 33 len 9 skipped (cotton_usb_host cotton-usb-host/src/wire.rs:328)
00:00:00.216808 [DEBUG]     EndpointDescriptor { bLength: 7, bDescriptorType: 5, bEndpointAddress: 130, bmAttributes: 3, wMaxPacketSize: [16, 0], bInterval: 1 } (cotton_usb_host cotton-usb-host/src/wire.rs:317)
00:00:00.216843 [DEBUG]   InterfaceDescriptor { bLength: 9, bDescriptorType: 4, bInterfaceNumber: 2, bAlternateSetting: 0, bNumEndpoints: 2, bInterfaceClass: 3, bInterfaceSubClass: 0, bInterfaceProtocol: 0, iInterface: 0 } (cotton_usb_host cotton-usb-host/src/wire.rs:314)
00:00:00.216872 [DEBUG]   class type 33 len 9 skipped (cotton_usb_host cotton-usb-host/src/wire.rs:328)
00:00:00.216910 [DEBUG]     EndpointDescriptor { bLength: 7, bDescriptorType: 5, bEndpointAddress: 131, bmAttributes: 3, wMaxPacketSize: [32, 0], bInterval: 4 } (cotton_usb_host cotton-usb-host/src/wire.rs:317)
00:00:00.216945 [DEBUG]     EndpointDescriptor { bLength: 7, bDescriptorType: 5, bEndpointAddress: 4, bmAttributes: 3, wMaxPacketSize: [32, 0], bInterval: 4 } (cotton_usb_host cotton-usb-host/src/wire.rs:317)
00:00:00.220219 [DEBUG] class 3 subclass 0 protocol 0 (cotton_usb_host_hid cotton-usb-host-hid/src/hid.rs:106)
00:00:00.220252 [DEBUG] class 3 subclass 0 protocol 0 (cotton_usb_host_hid cotton-usb-host-hid/src/hid.rs:106)
00:00:00.220283 [INFO ] - Could be HID... (rp2040_usb_hid_boot_keyboard src/bin/rp2040-usb-hid-boot-keyboard.rs:186)
00:00:00.223704 [INFO ] < Got HID device Hid(dev=UsbDevice { usb_address: 31, usb_speed: Full12, packet_size_ep0: 8, in_endpoints_bitmap: 14, out_endpoints_bitmap: 16 }, ep=1) (rp2040_usb_hid_boot_keyboard src/bin/rp2040-usb-hid-boot-keyboard.rs:202)
00:00:00.223758 [INFO ] - Press the Up/Down Arrow keys to control the LED on GPIO25! (rp2040_usb_hid_boot_keyboard src/bin/rp2040-usb-hid-boot-keyboard.rs:203)
00:00:00.223782 [DEBUG] > Sleeping on select... (rp2040_usb_hid_boot_keyboard src/bin/rp2040-usb-hid-boot-keyboard.rs:219)
00:00:00.223821 [DEBUG] interrupt_endpoint on pipe 1 (cotton_usb_host src/host/rp2040.rs:1589)
00:00:03.323547 [DEBUG] < Got Report(HidReport { bytes: [0, 0, 82, 0, 0, 0, 0, 0] }) (rp2040_usb_hid_boot_keyboard src/bin/rp2040-usb-hid-boot-keyboard.rs:221)
00:00:03.323642 [INFO ] < Raw Key: ArrowUp (LED On) (rp2040_usb_hid_boot_keyboard src/bin/rp2040-usb-hid-boot-keyboard.rs:248)
00:00:03.323665 [DEBUG] > Sleeping on select... (rp2040_usb_hid_boot_keyboard src/bin/rp2040-usb-hid-boot-keyboard.rs:219)
00:00:03.423518 [DEBUG] < Got Report(HidReport { bytes: [0, 0, 0, 0, 0, 0, 0, 0] }) (rp2040_usb_hid_boot_keyboard src/bin/rp2040-usb-hid-boot-keyboard.rs:221)
00:00:03.423560 [DEBUG] > Sleeping on select... (rp2040_usb_hid_boot_keyboard src/bin/rp2040-usb-hid-boot-keyboard.rs:219)
00:00:03.553512 [DEBUG] < Got Report(HidReport { bytes: [0, 0, 81, 0, 0, 0, 0, 0] }) (rp2040_usb_hid_boot_keyboard src/bin/rp2040-usb-hid-boot-keyboard.rs:221)
00:00:03.553557 [INFO ] < Raw Key: ArrowDown (LED Off) (rp2040_usb_hid_boot_keyboard src/bin/rp2040-usb-hid-boot-keyboard.rs:252)
00:00:03.553575 [DEBUG] > Sleeping on select... (rp2040_usb_hid_boot_keyboard src/bin/rp2040-usb-hid-boot-keyboard.rs:219)
```