### PR TITLE
USB-HID-Host: Non-breaking changes to support USB mice.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ So far:
  - [cotton-usb-host-hid](https://crates.io/crates/cotton-usb-host-hid)
    [![Crates.io](https://img.shields.io/crates/v/cotton-usb-host-hid)](https://crates.io/crates/cotton-usb-host-hid)
    [![Crates.io](https://img.shields.io/crates/d/cotton-usb-host-hid)](https://crates.io/crates/cotton-usb-host-hid)
-   [![docs.rs](https://img.shields.io/docsrs/cotton-usb-host-hid)](https://docs.rs/cotton-usb-host-hid/latest/cotton_usb-host-hid/): USB "Human Interface Device" (HID) keyboard support (i.e.,
-   supporting attaching USB keyboards to a microcontroller, to allow keyboard
+   [![docs.rs](https://img.shields.io/docsrs/cotton-usb-host-hid)](https://docs.rs/cotton-usb-host-hid/latest/cotton_usb-host-hid/): USB "Human Interface Device" (HID) keyboard & mouse support (i.e.,
+   supporting attaching USB keyboards & mice to a microcontroller, to allow keyboard & mouse
    input).
 
  - [cotton-usb-host-msc](https://crates.io/crates/cotton-usb-host-msc)

--- a/cotton-usb-host-hid/README.md
+++ b/cotton-usb-host-hid/README.md
@@ -20,4 +20,4 @@ help you if you want your microcontroller to _appear_ as a HID
 device when plugged into a USB host such a laptop -- that's the other
 way around!
 
-Currently only HID Keyboards in 'BIOS' mode are supported.
+Currently only HID Keyboards in 'BIOS' mode and mice are supported.

--- a/cotton-usb-host-hid/src/hid.rs
+++ b/cotton-usb-host-hid/src/hid.rs
@@ -47,7 +47,7 @@ impl<'a, HC: HostController> Hid<'a, HC> {
         Ok(Self { bus, device, in_ep })
     }
 
-    /// Produce a stream of HID reports from a Boot-mode keyboard
+    /// Produce a stream of HID reports from a Boot-mode keyboard or mouse
     pub fn handle(&mut self) -> impl Stream<Item = HidReport> + '_ {
         self.bus
             .interrupt_endpoint_in(
@@ -77,6 +77,7 @@ pub struct IdentifyHid {
     hid_configuration: Option<u8>,
     hid_interface: bool,
     hid_endpoint: Option<u8>,
+    hid_match_type: IdentifyHidType
 }
 
 impl IdentifyHid {
@@ -98,6 +99,16 @@ impl IdentifyHid {
     pub fn endpoint(&self) -> Option<u8> {
         self.hid_endpoint
     }
+
+    pub fn new(hid_type: IdentifyHidType) -> Self {
+        IdentifyHid {
+            current_configuration: None,
+            hid_configuration: None,
+            hid_interface: false,
+            hid_endpoint: None,
+            hid_match_type: hid_type
+        }
+    }
 }
 
 impl DescriptorVisitor for IdentifyHid {
@@ -108,13 +119,11 @@ impl DescriptorVisitor for IdentifyHid {
         self.hid_interface = match (
             i.bInterfaceClass,
             i.bInterfaceSubClass,
-            i.bInterfaceProtocol,
         ) {
             (
                 Self::INTERFACE_CLASS,
                 Self::INTERFACE_SUBCLASS_BOOT,
-                Self::INTERFACE_PROTOCOL_KEYBOARD,
-            ) => {
+            ) if self.hid_match_type.match_protocol(i.bInterfaceProtocol) => {
                 self.hid_configuration = self.current_configuration;
                 true
             }
@@ -140,6 +149,30 @@ impl DescriptorVisitor for IdentifyHid {
 impl IdentifyFromDescriptors for IdentifyHid {
     fn identify(&self) -> Option<u8> {
         self.hid_configuration
+    }
+}
+
+#[derive(Default)]
+pub enum IdentifyHidType {
+    #[default]
+    Keyboard,
+    Mouse,
+    Both
+}
+
+impl IdentifyHidType {
+    /// This is the bInterfaceProtocol for Keyboards
+    pub const INTERFACE_PROTOCOL_KEYBOARD: u8 = 1;
+    /// This is the bInterfaceProtocol for Mice
+    pub const INTERFACE_PROTOCOL_MOUSE: u8 = 2;
+
+    pub fn match_protocol(&self, interface_type: u8) -> bool {
+        match self {
+            Self::Keyboard => interface_type == Self::INTERFACE_PROTOCOL_KEYBOARD,
+            Self::Mouse => interface_type == Self::INTERFACE_PROTOCOL_MOUSE,
+            Self::Both => interface_type == Self::INTERFACE_PROTOCOL_KEYBOARD || 
+                interface_type == Self::INTERFACE_PROTOCOL_MOUSE,
+        }
     }
 }
 

--- a/cotton-usb-host-hid/src/hid.rs
+++ b/cotton-usb-host-hid/src/hid.rs
@@ -28,7 +28,7 @@ where
 
 /// A report from our HID device
 ///
-/// NB: Only supports 8-byte reports from a Boot mode keyboard.
+/// NB: Only supports 8-byte reports from a Boot mode keyboard & mice.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct HidReport {


### PR DESCRIPTION
## Preface

I was working on a USB adaptor for a 40 year old IR keyboard and mouse protocol; this is as far as I can tell the easiest solution I have found for acting as an embedded USB HID host. 

I had used this library to make a working POC for the keyboard, but I wanted to make mice also work; 

I had checked [OS-Dev wiki](https://wiki.osdev.org/USB_Human_Interface_Devices) on USB HiD, and [hid1_11.pdf appendix B](https://www.usb.org/sites/default/files/hid1_11.pdf) (this is mentioned in a doc comment in `cotton-usb-host-hid/src/hid.rs`) and I couldn't find any reason why the current keyboard implementation couldn't just work for USB mice if `IdentifyHid` checked for the `bInterfaceProtocol` code (1 = keyboard, 2 = mice) when checking the interface descriptor in the `on_interface` method. 

I experimented this in a throaway fork [hid.rs#L116](https://forgejo.crashtest.dev/jasonalexander-ja/pico-hid-experiments/src/branch/main/cotton-usb-host-hid/src/hid.rs#L116) where I simple just let it check for `INTERFACE_PROTOCOL_KEYBOARD` or 2 (for mice) in the `on_interface` method. 

To test this I then adapted the existing [RP2040 RTIC example](https://forgejo.crashtest.dev/jasonalexander-ja/pico-hid-experiments/src/branch/main/cross/rp2040-w5500-rtic2/src/bin/rp2040-usb-hid-boot-keyboard.rs#L238) to work as a USB -> legacy IR mouse adaptor and it confirmed that it did just work as I had expected, the USB reports are defined as 3 bytes long, with any other data being optional and device specific, so it fits within the 8 byte `HidReport` buffer. 

[Video on Mastodon of the implementation working](https://woof.tech/@crashtestdev/115715072242669893)

## Changes 

I have now tried to clean up and work these changes into non-breaking changes in the actual library; to start I added a [IdentifyHidType](https://github.com/jasonalexander-ja/cotton/blob/main/cotton-usb-host-hid/src/hid.rs#L163) enum which defines which HID type device the library users wishes to identify, either Keyboard, Mouse, or both and defaults to `Keyboard`, it also contains a helper method to match the correct `bInterfaceProtocol` based on its current variant. 

I then added a `hid_match_type: IdentifyHidType` member to [IdentifyHid](https://github.com/jasonalexander-ja/cotton/blob/main/cotton-usb-host-hid/src/hid.rs#L80), this defaults to `Keyboard` when `IdentifyHid::default` is called, and can be manually set using a new method [IdentifyHid::new](https://github.com/jasonalexander-ja/cotton/blob/main/cotton-usb-host-hid/src/hid.rs#L103). 

I then modified the [IdentifyHid::on_interface](https://github.com/jasonalexander-ja/cotton/blob/main/cotton-usb-host-hid/src/hid.rs#L118) method to call the `IdentifyHidType::match_protocol` on the `IdentifyHid::hid_match_type`, passing the `bInterfaceProtocol` of the interface descriptor when matching whether the interface is a HID of the desired type. 

This means existing uses of this library still work exactly as expected, only matching USB boot mode keyboards when `IdentifyHid::on_interface` is called, but with the optional functionality to match on USB mice or both mice and keyboards. 