### PR TITLE
Add i.MX RT processor support information to README

### DIFF
--- a/cotton-usb-host/README.md
+++ b/cotton-usb-host/README.md
@@ -156,6 +156,9 @@ The RP2040 support is in this repo to provide a convenient worked example;
 specific host-controller support for other microcontrollers probably
 belongs in those microcontrollers' HAL crates.
 
+Support for i.MX RT processors (such as used in the Teensy 4.1) has been
+implemented in [imxrt-usbh](https://github.com/imxrt-rs/imxrt-usbh).
+
 ## TODO
 
 TODO before merge


### PR DESCRIPTION

Also, did https://github.com/pdh11/cotton/commit/b876eaad43f4f4ee1a246a6a2e8f53d933d4e937 fix this open issue in the README, or is that something else?

 - [ ] Remove from HubEventStream on disconnect
